### PR TITLE
Add CLI entry for jest-to-vitest-codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ describe('my test', () => {
 });
 ```
 
+### CLI
+
+Run the codemod over a directory directly from the command line:
+
+```bash
+npx jest-to-vitest-codemod ./src
+```
+
 ### Advanced Usage with Codemod Framework
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist"
   ],
+  "bin": {
+    "jest-to-vitest-codemod": "./dist/cli.js"
+  },
   "license": "MIT",
   "packageManager": "pnpm@10.12.4",
   "engines": {

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
+  source: {
+    entry: {
+      index: './src/index.ts',
+      cli: './src/cli.ts',
+    },
+  },
   lib: [
     {
       format: 'esm',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { runCodemods } from '@kamaalio/codemod-kit';
+
+import { JEST_TO_VITEST_CODEMOD } from './codemods/jest-to-vitest/index.js';
+
+async function main(): Promise<void> {
+  const [target] = process.argv.slice(2);
+  if (!target) {
+    console.error('Usage: jest-to-vitest-codemod <path>');
+    process.exit(1);
+  }
+
+  await runCodemods([JEST_TO_VITEST_CODEMOD], target, { rootPaths: [target] });
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const CLI_PATH = join(process.cwd(), 'dist/cli.js');
+
+function runCli(dir: string) {
+  const result = spawnSync('node', [CLI_PATH, dir], {
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `exit ${result.status}`);
+  }
+}
+
+beforeAll(() => {
+  const build = spawnSync('pnpm', ['build'], { encoding: 'utf-8' });
+  if (build.status !== 0) {
+    throw new Error(build.stderr || `build failed with exit ${build.status}`);
+  }
+});
+
+describe('cli', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'jtv-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('transforms files in place', async () => {
+    const filePath = join(tempDir, 'test.spec.ts');
+    const source = "describe('a', () => { it('b', () => { expect(true).toBe(true); }); });";
+    await writeFile(filePath, source);
+
+    runCli(tempDir);
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain("from 'vitest'");
+  });
+});


### PR DESCRIPTION
## Summary
- add a CLI implementation using `runCodemods`
- expose the binary through `package.json`
- document CLI usage in the README
- test the new CLI behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686592382fc48328ba802874620c79b3