### PR TITLE
Ensuring vitest Mock contains a function param

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["CODEMOD", "Codemods"]
+}

--- a/src/codemods/jest-to-vitest/rules/jest-mock-type-to-vitest.ts
+++ b/src/codemods/jest-to-vitest/rules/jest-mock-type-to-vitest.ts
@@ -3,12 +3,38 @@ import {
   type FindAndReplaceConfig,
   type Modifications,
 } from '@kamaalio/codemod-kit';
+import { asserts } from '@kamaalio/kamaal';
+
+const TEST_FRAMEWORK_NAMES = ['jest', 'vi'];
 
 const EDIT_CONFIG: FindAndReplaceConfig = {
   rule: {
-    any: ['jest', 'vi'].map(prefix => ({ kind: 'nested_type_identifier', regex: `${prefix}.Mock` })),
+    any: TEST_FRAMEWORK_NAMES.map(prefix => ({ kind: 'nested_type_identifier', regex: `${prefix}\\.Mock` })),
   },
-  transformer: 'Mock',
+  transformer: node => {
+    const parent = node.parent();
+    asserts.invariant(parent != null, 'Mock identifier should have a parent');
+
+    const defaultReplacement = 'Mock';
+    const hasFunctionGenericParam = parent.find({ rule: { kind: 'function_type' } }) != null;
+    if (hasFunctionGenericParam) return defaultReplacement;
+
+    const parentText = parent.text();
+    const genericParamStart = parentText.indexOf('<');
+    const doesNotHaveAGenericParam = genericParamStart === -1;
+    if (doesNotHaveAGenericParam) return defaultReplacement;
+
+    let modifiedText =
+      `${parentText.slice(0, genericParamStart + 1)}(...params: Array<unknown>) => ${parentText.slice(genericParamStart + 1)}`.trim();
+    for (const testFrameworkName of TEST_FRAMEWORK_NAMES) {
+      if (!modifiedText.startsWith(testFrameworkName)) continue;
+
+      modifiedText = modifiedText.slice(testFrameworkName.length + 1);
+      break;
+    }
+
+    return parent.replace(modifiedText);
+  },
 };
 
 async function jestMockTypeToVitest(modifications: Modifications): Promise<Modifications> {

--- a/tests/codemods/jest-to-vitest/rules/__snapshots__/jest-mock-type-to-vitest.test.ts.snap
+++ b/tests/codemods/jest-to-vitest/rules/__snapshots__/jest-mock-type-to-vitest.test.ts.snap
@@ -1,5 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`jestMockTypeToVitest > removes jest from jest.Mock 1`] = `"let fn: Mock<(name: string) => number>"`;
+exports[`jestMockTypeToVitest > removes jest from jest.Mock ['jest'] 1`] = `"let fn: Mock<(name: string) => number>"`;
 
-exports[`jestMockTypeToVitest > removes vi from vi.Mock 1`] = `"let fn: Mock<(name: string) => number>"`;
+exports[`jestMockTypeToVitest > removes jest from jest.Mock ['vi'] 1`] = `"let fn: Mock<(name: string) => number>"`;
+
+exports[`jestMockTypeToVitest > removes jest from jest.Mock and ensure generic param is a function ['jest'] 1`] = `"let fn: Mock<(...params: Array<unknown>) => string>"`;
+
+exports[`jestMockTypeToVitest > removes jest from jest.Mock and ensure generic param is a function ['vi'] 1`] = `"let fn: Mock<(...params: Array<unknown>) => string>"`;
+
+exports[`jestMockTypeToVitest > removes jest from jest.Mock without generic param ['jest'] 1`] = `"let fn: Mock"`;
+
+exports[`jestMockTypeToVitest > removes jest from jest.Mock without generic param ['vi'] 1`] = `"let fn: Mock"`;


### PR DESCRIPTION
This PR ensures that when converting `jest.Mock` or `vi.Mock` types without a function generic, a default function signature is injected. Key changes include adding a test, updating the transformer logic, refreshing the snapshot, and adding VS Code settings.

- Added a new test case for non-function generics in `jest.Mock`
- Updated the codemod transformer to wrap non-function generics in a default function signature